### PR TITLE
Solve spire agent reattestation on restart

### DIFF
--- a/conf/agent/agent.conf
+++ b/conf/agent/agent.conf
@@ -4,7 +4,7 @@ agent {
     server_address = "localhost"
     server_port = "8081"
     agent_address = "127.0.0.1"
-    agent_port = "9098"
+    agent_port = "9091"
     socket_path ="/tmp/spire-agent/public/api.sock"
     #trust_bundle_path = "./conf/agent/dummy_root_ca.crt"
     insecure_bootstrap = true
@@ -17,13 +17,15 @@ plugins {
         plugin_data {
         }
     }
-    KeyManager "disk" {
+    KeyManager "keymanager-k8s" {
+        plugin_cmd = "/config/plugin/spire-k8s-keymanager-k8s"
         plugin_data {
-            directory = "./.data"
+            namespace = "accuknox-agents"
+            secretname = "spire-agent-secret"
         }
     }
     WorkloadAttestor "k8sw_sat" {
-        plugin_cmd = "/home/zero/spire-k8ssat-plugin/plugin"
+        plugin_cmd = "/config/plugin/k8s-sat"
         plugin_data {
         }
     }

--- a/pkg/agent/attestor/node/node_test.go
+++ b/pkg/agent/attestor/node/node_test.go
@@ -428,7 +428,7 @@ func (c *fakeBundleService) GetBundle(ctx context.Context, in *bundlev1.GetBundl
 func prepareTestDir(t *testing.T, cachedSVID, cachedBundle *x509.Certificate, cachedReattestable bool) storage.Storage {
 	dir := spiretest.TempDir(t)
 
-	sto, err := storage.Open(dir)
+	sto, err := storage.Open(dir, "", "")
 	require.NoError(t, err)
 
 	if cachedSVID != nil {

--- a/pkg/agent/manager/manager_test.go
+++ b/pkg/agent/manager/manager_test.go
@@ -1700,7 +1700,7 @@ func svidsEqual(as, bs []*x509.Certificate) bool {
 }
 
 func openStorage(t *testing.T, dir string) storage.Storage {
-	sto, err := storage.Open(dir)
+	sto, err := storage.Open(dir, "", "")
 	require.NoError(t, err)
 	return sto
 }

--- a/pkg/agent/storage/storage_test.go
+++ b/pkg/agent/storage/storage_test.go
@@ -263,7 +263,7 @@ func TestSVID(t *testing.T) {
 }
 
 func openStorage(t *testing.T, dir string) Storage {
-	sto, err := Open(dir)
+	sto, err := Open(dir, "", "")
 	require.NoError(t, err)
 	return sto
 }

--- a/pkg/common/util/k8sClient.go
+++ b/pkg/common/util/k8sClient.go
@@ -1,0 +1,162 @@
+package util
+
+import (
+	"context"
+	"flag"
+	"os"
+	"path/filepath"
+
+	logr "github.com/sirupsen/logrus"
+
+	"k8s.io/client-go/kubernetes"
+	rest "k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+)
+
+var parsed bool = false
+var kubeconfig *string
+
+func isInCluster() bool {
+	if _, ok := os.LookupEnv("KUBERNETES_PORT"); ok {
+		return true
+	}
+
+	return false
+}
+
+func ConnectK8sClient() *kubernetes.Clientset {
+	if isInCluster() {
+		return ConnectInClusterAPIClient()
+	}
+
+	return ConnectLocalAPIClient()
+}
+
+func ConnectLocalAPIClient() *kubernetes.Clientset {
+	if !parsed {
+		homeDir := ""
+		if h := os.Getenv("HOME"); h != "" {
+			homeDir = h
+		} else {
+			homeDir = os.Getenv("USERPROFILE") // windows
+		}
+
+		envKubeConfig := os.Getenv("KUBECONFIG")
+		if envKubeConfig != "" {
+			kubeconfig = &envKubeConfig
+		} else {
+			if home := homeDir; home != "" {
+				kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+			} else {
+				kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+			}
+			flag.Parse()
+		}
+
+		parsed = true
+	}
+
+	// use the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if err != nil {
+		logr.WithError(err).Error("Failed to create config")
+		return nil
+	}
+
+	// creates the clientset
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		logr.WithError(err).Error("Failed to create clientset")
+		return nil
+	}
+
+	return clientset
+}
+
+func ConnectInClusterAPIClient() *kubernetes.Clientset {
+	host := ""
+	port := ""
+	token := ""
+
+	if val, ok := os.LookupEnv("KUBERNETES_SERVICE_HOST"); ok {
+		host = val
+	} else {
+		host = "127.0.0.1"
+	}
+
+	if val, ok := os.LookupEnv("KUBERNETES_PORT_443_TCP_PORT"); ok {
+		port = val
+	} else {
+		port = "6443"
+	}
+
+	read, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/token")
+	if err != nil {
+		logr.WithError(err).Error("Failed to read token")
+		return nil
+	}
+
+	token = string(read)
+
+	// create the configuration by token
+	kubeConfig := &rest.Config{
+		Host:        "https://" + host + ":" + port,
+		BearerToken: token,
+		TLSClientConfig: rest.TLSClientConfig{
+			Insecure: true,
+		},
+	}
+
+	if client, err := kubernetes.NewForConfig(kubeConfig); err != nil {
+		logr.WithError(err).Error("Failed to create client")
+		return nil
+	} else {
+		return client
+	}
+}
+
+func CreateK8sSecrets(namespace, secretname string, data map[string][]byte) error {
+
+	client := ConnectK8sClient()
+
+	secret := &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: secretname,
+		},
+		Data: data,
+		Type: v1.SecretTypeOpaque,
+	}
+
+	oldSec, err := GetK8sSecrets(namespace, secretname)
+	if err == nil {
+
+		oldData := oldSec.Data
+
+		for k, v := range oldData {
+			data[k] = v
+		}
+		oldSec.Data = data
+		_, err := client.CoreV1().Secrets(namespace).Update(context.Background(), &oldSec, metav1.UpdateOptions{})
+		if err != nil {
+			return err
+		}
+	} else {
+		_, err = client.CoreV1().Secrets(namespace).Create(context.Background(), secret, metav1.CreateOptions{})
+
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func GetK8sSecrets(namespace, secretname string) (v1.Secret, error) {
+	client := ConnectK8sClient()
+	secret, err := client.CoreV1().Secrets(namespace).Get(context.Background(), secretname, metav1.GetOptions{})
+	return *secret, err
+}


### PR DESCRIPTION
- Updated storage package by adding functions to store svid,bundle,modified time etc as kubernetes secret
- Updated agent run function to check for k8s KeyManager plugin and if found use storage as kubernetes secret rather than directory
- Updated agent config file to include the new plugin configurations

Signed-off-by: Vishnu Soman <vishnu@accuknox.com>