### PR TITLE
fix(ci): replace SPIRE_SYSTEMD_TOKEN with GH_ORG_TOKEN

### DIFF
--- a/.github/workflows/spire-agent-action.yaml
+++ b/.github/workflows/spire-agent-action.yaml
@@ -19,7 +19,7 @@ jobs:
     - uses: rubenesp87/semver-validation-action@0.1.0
       with:
        version: ${{ github.ref_name }}
-  
+
   vulnerability-scan-agent:
     runs-on: ubuntu-latest
     needs: [tag-validate]
@@ -27,9 +27,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 0 
+        fetch-depth: 0
         submodules: recursive
-        token: ${{ secrets.SPIRE_SYSTEMD_TOKEN }}
+        token: ${{ secrets.GH_ORG_TOKEN }}
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/.github/workflows/spire-agent-systemd-release.yaml
+++ b/.github/workflows/spire-agent-systemd-release.yaml
@@ -9,7 +9,7 @@ on:
         required: true
   push:
     tags:
-      - "*"  
+      - "*"
 
 permissions: read-all
 
@@ -17,14 +17,14 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  
+      contents: write
     steps:
       - uses: actions/checkout@v3
         with:
-          fetch-depth: 0 
+          fetch-depth: 0
           submodules: recursive
-          token: ${{ secrets.SPIRE_SYSTEMD_TOKEN }}
-        
+          token: ${{ secrets.GH_ORG_TOKEN }}
+
       - name: Check out tag
         run: |
           git fetch --tags
@@ -47,7 +47,7 @@ jobs:
         uses: goreleaser/goreleaser-action@v6
         with:
           version: v1.25.0
-          args: release --rm-dist 
+          args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GOPRIVATE: github.com/accuknox

--- a/.github/workflows/spire-server-action.yaml
+++ b/.github/workflows/spire-server-action.yaml
@@ -19,7 +19,7 @@ jobs:
     - uses: rubenesp87/semver-validation-action@0.1.0
       with:
        version: ${{ github.ref_name }}
-  
+
   vulnerability-scan-server:
     runs-on: ubuntu-latest
     needs: [tag-validate]
@@ -27,9 +27,9 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        fetch-depth: 0 
+        fetch-depth: 0
         submodules: recursive
-        token: ${{ secrets.SPIRE_SYSTEMD_TOKEN }}
+        token: ${{ secrets.GH_ORG_TOKEN }}
 
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
`SPIRE_SYSTEMD_TOKEN` org secret has expired. Deprecating it in favor of `GH_ORG_TOKEN`